### PR TITLE
feat(judge): env-wired OpenAI-compatible VLM judge

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,13 @@ a hard validator, and curated presets (`open-video list-presets`).
 |---|---|---|
 | **Generate** | Local MiniMax H3 via ComfyUI — `pull` / `status` / `run` | Multi-model backends (Wan, LTX, …) |
 | **Agent path** | `skill/h3-video` crafts official prompts + drives the CLI | Full multi-shot director agent |
-| **Judge loop** | Scaffold in `core/judge.py` (**PASSes without a vision fn**) | Vision score → refine → best-of-N |
+| **Judge loop** | Real VLM judge via env `OPEN_VIDEO_VLM_URL/MODEL/KEY` (OpenAI-compatible); honest PASS stub when unset | Refine loop → best-of-N |
 | **Long film** | Single clips (H3 shot length) | Planner → stitch multi-minute film |
 | **Hosted try** | Site `/try` is a **browser mockup** | Real hosted generate |
 
-The generate → judge → refine loop is the long-term design. It is **not** a live vision judge
-in v0.0.1 — the architecture diagrams describe the target, not what ships today.
+The full generate → judge → **refine** loop is the long-term design; today the judge scores and
+diagnoses (point `OPEN_VIDEO_VLM_URL` at any OpenAI-compatible vision model), and refine/regenerate
+is still manual.
 
 ## Why local
 

--- a/core/judge.py
+++ b/core/judge.py
@@ -1,15 +1,15 @@
-"""open-video quality judge scaffold (generate → judge → refine design).
+"""open-video quality judge (generate → judge → refine).
 
-v0.0.1: frame extraction + PASS stub unless a real vision_fn is provided.
-Not a shipped multi-minute film product — wire a vision model for real scores.
+Frame extraction + vision assessment. A real vision model activates via env
+(OPEN_VIDEO_VLM_URL / OPEN_VIDEO_VLM_MODEL / OPEN_VIDEO_VLM_KEY — see
+judges/openai_compat.py) or an explicit ``vision_fn``. Without either, the
+judge is an honest PASS stub.
 
 Usage:
-    judge = QualityJudge(vision_fn=my_vision_api)
+    judge = QualityJudge.from_env()          # env-wired (or PASS stub)
+    judge = QualityJudge(vision_fn=my_api)   # explicit
     v = judge.assess(video_path, prompt, shot_id=1)
     if v.verdict == "REFINE": apply(v.issues)  # fix + regenerate
-
-v0: frame extraction + PASS stub (ready for vision wiring).
-v1: vision model → score + diagnose (planned).
 """
 import subprocess, json
 from pathlib import Path
@@ -41,6 +41,14 @@ class QualityJudge:
         self.bar = quality_bar
         self.n = n_frames
         self.vision_fn = vision_fn   # callable(frames: list[str], prompt: str) → dict
+
+    @classmethod
+    def from_env(cls, **kwargs) -> "QualityJudge":
+        """Judge wired to the env-configured VLM, or the PASS stub when unset."""
+        if "vision_fn" not in kwargs:
+            from open_video.judges.openai_compat import vision_fn_from_env
+            kwargs["vision_fn"] = vision_fn_from_env()
+        return cls(**kwargs)
 
     def extract_frames(self, video_path: str, shot_id: int, frames_dir: str = "output/frames") -> list:
         """Extract N evenly-spaced frames from the video for the judge."""

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -49,7 +49,12 @@ class LongFilmPipeline:
         self.out.mkdir(parents=True, exist_ok=True)
         self.frames.mkdir(parents=True, exist_ok=True)
         # core modules — single source of truth for judge / stitch / recipe logic
-        self._judge = QualityJudge(vision_fn=vision_fn)
+        # explicit vision_fn wins; otherwise env (OPEN_VIDEO_VLM_*) wires a real
+        # judge and unset env keeps the honest PASS stub
+        if vision_fn is not None:
+            self._judge = QualityJudge(vision_fn=vision_fn)
+        else:
+            self._judge = QualityJudge.from_env()
         self._stitcher = Stitcher(output_dir=str(self.out))
 
     # --- the judge (delegates to core.judge.QualityJudge) ---

--- a/judges/openai_compat.py
+++ b/judges/openai_compat.py
@@ -1,0 +1,103 @@
+"""OpenAI-compatible VLM client — the default real ``vision_fn`` for QualityJudge.
+
+Stdlib only (urllib), same policy as the rest of the runtime. Activated by env:
+
+    OPEN_VIDEO_VLM_URL     chat-completions endpoint, e.g.
+                           https://integrate.api.nvidia.com/v1/chat/completions
+                           http://127.0.0.1:8000/v1/chat/completions
+    OPEN_VIDEO_VLM_MODEL   a vision-capable chat model id
+    OPEN_VIDEO_VLM_KEY     bearer token (optional for local servers)
+
+With URL+MODEL set, ``QualityJudge.from_env()`` judges for real; without them it
+keeps the honest v0 PASS-stub behavior.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.request
+
+_SYSTEM = (
+    "You are a strict video-quality judge. You are shown evenly spaced frames "
+    "from one generated video shot plus the prompt that requested it. Reply "
+    "with ONLY a JSON object, no prose, using exactly these keys: "
+    '{"score": <float 0.0-1.0 overall quality/adherence>, '
+    '"missing_elements": [<prompt elements not visible>], '
+    '"artifacts": <"" or short description of visual artifacts>, '
+    '"motion_quality": <"good"|"acceptable"|"poor" judged from frame-to-frame change>, '
+    '"incoherence": <false or short description if frames do not flow>}'
+)
+
+_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp"}
+
+
+def _frame_part(path: str) -> dict:
+    ext = os.path.splitext(path)[1].lower()
+    mime = _MIME.get(ext, "image/png")
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+    return {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}}
+
+
+def _parse_verdict(content: str) -> dict:
+    """Extract the JSON verdict object from a model reply (tolerates code fences)."""
+    text = content.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.startswith("json"):
+            text = text[4:]
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError(f"vision model returned no JSON object: {content[:200]!r}")
+    out = json.loads(text[start : end + 1])
+    if not isinstance(out, dict) or "score" not in out:
+        raise ValueError(f"vision verdict missing 'score': {content[:200]!r}")
+    out["score"] = float(out["score"])
+    return out
+
+
+def make_vision_fn(url: str, model: str, api_key: str | None = None, timeout: float = 120.0):
+    """Build a ``vision_fn(frames, prompt) -> dict`` against an OpenAI-compatible endpoint.
+
+    Failures (HTTP error, non-JSON reply) raise — a judge that cannot judge must
+    not silently PASS.
+    """
+
+    def vision_fn(frames: list, prompt: str) -> dict:
+        content = [
+            {
+                "type": "text",
+                "text": (
+                    f"Prompt for this shot:\n{prompt}\n\n"
+                    f"The {len(frames)} frames follow in temporal order. Judge the shot."
+                ),
+            }
+        ] + [_frame_part(p) for p in frames]
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": _SYSTEM},
+                {"role": "user", "content": content},
+            ],
+            "temperature": 0,
+            "max_tokens": 512,
+        }
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        req = urllib.request.Request(url, data=json.dumps(payload).encode(), headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = json.loads(resp.read().decode())
+        return _parse_verdict(body["choices"][0]["message"]["content"])
+
+    return vision_fn
+
+
+def vision_fn_from_env():
+    """Return a real vision_fn if OPEN_VIDEO_VLM_URL + OPEN_VIDEO_VLM_MODEL are set, else None."""
+    url = os.environ.get("OPEN_VIDEO_VLM_URL", "").strip()
+    model = os.environ.get("OPEN_VIDEO_VLM_MODEL", "").strip()
+    if not url or not model:
+        return None
+    return make_vision_fn(url, model, api_key=os.environ.get("OPEN_VIDEO_VLM_KEY") or None)

--- a/tests/test_judge_vlm.py
+++ b/tests/test_judge_vlm.py
@@ -1,0 +1,137 @@
+"""Real-path tests for the OpenAI-compatible VLM judge wiring.
+
+A local HTTP server plays the vision endpoint (no mocks of our own code):
+make_vision_fn does real urllib POSTs; parsing, diagnosis, and env activation
+are asserted against captured requests and real return values.
+"""
+import base64
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from open_video.judges.openai_compat import (  # noqa: E402
+    make_vision_fn,
+    vision_fn_from_env,
+    _parse_verdict,
+)
+from open_video.core.judge import QualityJudge  # noqa: E402
+
+# 1x1 transparent PNG
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+class _Endpoint:
+    """Local OpenAI-style chat endpoint capturing requests, serving a canned verdict."""
+
+    def __init__(self, verdict_content: str):
+        self.requests = []
+        endpoint = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                endpoint.requests.append({"headers": dict(self.headers), "body": body})
+                reply = {"choices": [{"message": {"content": verdict_content}}]}
+                data = json.dumps(reply).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def log_message(self, *a):
+                pass
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self.server.server_port}/v1/chat/completions"
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
+def _frames(tmp_path, n=2):
+    paths = []
+    for i in range(n):
+        p = tmp_path / f"f{i}.png"
+        p.write_bytes(_PNG)
+        paths.append(str(p))
+    return paths
+
+
+def test_vision_fn_posts_frames_and_parses_verdict(tmp_path):
+    ep = _Endpoint(json.dumps({"score": 0.9, "missing_elements": [], "artifacts": "",
+                               "motion_quality": "good", "incoherence": False}))
+    try:
+        fn = make_vision_fn(ep.url, "test-vlm", api_key="sk-test")
+        out = fn(_frames(tmp_path), "waves at sunset")
+    finally:
+        ep.close()
+    assert out["score"] == 0.9
+    req = ep.requests[0]
+    assert req["headers"]["Authorization"] == "Bearer sk-test"
+    assert req["body"]["model"] == "test-vlm"
+    user = req["body"]["messages"][1]["content"]
+    images = [part for part in user if part["type"] == "image_url"]
+    assert len(images) == 2
+    assert images[0]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert "waves at sunset" in user[0]["text"]
+
+
+def test_low_score_yields_refine_with_issues(tmp_path):
+    verdict = {"score": 0.3, "missing_elements": ["flag"], "artifacts": "banding",
+               "motion_quality": "poor", "incoherence": False}
+    ep = _Endpoint(f"```json\n{json.dumps(verdict)}\n```")  # fenced reply tolerated
+    try:
+        judge = QualityJudge(vision_fn=make_vision_fn(ep.url, "test-vlm"))
+        raw = judge.vision_fn(_frames(tmp_path), "astronaut plants a flag")
+        issues = judge.diagnose(raw, "astronaut plants a flag")
+        verdict_out = "PASS" if raw["score"] >= judge.bar and not issues else "REFINE"
+    finally:
+        ep.close()
+    assert raw["score"] == 0.3
+    types = {i.type for i in issues}
+    assert {"dropped_element", "artifact", "bad_motion"} <= types
+    assert verdict_out == "REFINE"
+
+
+def test_non_json_reply_raises(tmp_path):
+    ep = _Endpoint("Sure! The video looks great to me.")
+    try:
+        fn = make_vision_fn(ep.url, "test-vlm")
+        try:
+            fn(_frames(tmp_path), "anything")
+            raised = False
+        except ValueError:
+            raised = True
+    finally:
+        ep.close()
+    assert raised, "a judge that cannot parse a verdict must raise, not silently PASS"
+
+
+def test_parse_verdict_requires_score():
+    try:
+        _parse_verdict('{"notes": "no score here"}')
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_env_activation(monkeypatch):
+    monkeypatch.delenv("OPEN_VIDEO_VLM_URL", raising=False)
+    monkeypatch.delenv("OPEN_VIDEO_VLM_MODEL", raising=False)
+    assert vision_fn_from_env() is None
+    assert QualityJudge.from_env().vision_fn is None
+
+    monkeypatch.setenv("OPEN_VIDEO_VLM_URL", "http://127.0.0.1:9/v1/chat/completions")
+    monkeypatch.setenv("OPEN_VIDEO_VLM_MODEL", "test-vlm")
+    assert vision_fn_from_env() is not None
+    assert QualityJudge.from_env().vision_fn is not None


### PR DESCRIPTION
Improve-1 of the post-launch campaign: the audits' top finding was that the advertised quality loop was a PASS stub. This wires a real, stdlib-only OpenAI-compatible VLM client activated by env (OPEN_VIDEO_VLM_URL / OPEN_VIDEO_VLM_MODEL / OPEN_VIDEO_VLM_KEY). Explicit vision_fn still wins; without env the honest stub remains and the README says so. Parse/HTTP failures raise loudly instead of silently passing. Tested against a live local HTTP endpoint (request capture, fenced-JSON tolerance, REFINE diagnosis, env activation) — 42/42.