### PR TITLE
fix(state): state-root split + pure imports (wheel hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
           stray=$(ls /tmp/wheel-venv/lib/python*/site-packages | grep -vE '^(open_video|.*\.dist-info|pip|setuptools|wheel|pkg_resources|__pycache__)$' || true)
           if [ -n "$stray" ]; then echo "stray top-level packages: $stray"; exit 1; fi
 
+      - name: Importing shipped modules must not write into site-packages
+        run: |
+          cd /tmp
+          /tmp/wheel-venv/bin/python -c "import open_video.scripts.h3_agent, open_video.scripts.h3_generate_benchmark, open_video.judges"
+          extra=$(find /tmp/wheel-venv/lib/python*/site-packages/open_video -type d \( -name output -o -name artifacts \) | head -1)
+          if [ -n "$extra" ]; then echo "import created state dir in site-packages: $extra"; exit 1; fi
+
   lint-shell:
     name: install.sh policy
     runs-on: ubuntu-latest

--- a/core/config.py
+++ b/core/config.py
@@ -3,15 +3,32 @@ import os
 from pathlib import Path
 
 # Paths
-ROOT = Path(__file__).resolve().parent.parent  # open-video/
+ROOT = Path(__file__).resolve().parent.parent  # open-video/ (source) or site-packages/open_video (wheel)
 LIBRARY = ROOT / "library"
 BACKENDS = ROOT / "backends"
 ENGINES = ROOT / "engines"
 JUDGES = ROOT / "judges"
 TEMPLATES = ROOT / "templates"
 BENCH = ROOT / "bench"
-OUTPUT = ROOT / "output"
-ARTIFACTS = ROOT / "artifacts"
+
+
+def is_installed_path(p: Path) -> bool:
+    """True when ``p`` lives inside an installed package tree (site/dist-packages)."""
+    return any(part in ("site-packages", "dist-packages") for part in p.parts)
+
+
+# Mutable state (outputs, artifacts, model fallbacks) must never land inside an
+# installed package tree. Source checkout keeps the historical repo-relative
+# behavior; a wheel install defaults to ~/.open-video (override: OPEN_VIDEO_HOME).
+_home = os.environ.get("OPEN_VIDEO_HOME", "").strip()
+if _home:
+    STATE_ROOT = Path(_home).expanduser()
+elif is_installed_path(ROOT):
+    STATE_ROOT = Path.home() / ".open-video"
+else:
+    STATE_ROOT = ROOT
+OUTPUT = STATE_ROOT / "output"
+ARTIFACTS = STATE_ROOT / "artifacts"
 
 # Engine defaults
 COMFYUI_SERVER = os.environ.get("OPEN_VIDEO_COMFYUI", "http://127.0.0.1:8188")

--- a/core/h3_weights.py
+++ b/core/h3_weights.py
@@ -86,6 +86,10 @@ def default_models_dir(repo_root: Optional[Path] = None) -> Path:
 
     root = Path(repo_root) if repo_root else Path.cwd()
     root = root.resolve()
+    from open_video.core.config import is_installed_path
+    if is_installed_path(root):
+        # wheel install: never target site-packages for a ~54 GB pull
+        return (Path.home() / ".open-video" / "models").resolve()
     sibling_lab = (root.parent / "lab" / "h3_models")
     if sibling_lab.is_dir():
         return sibling_lab.resolve()

--- a/scripts/h3_agent.py
+++ b/scripts/h3_agent.py
@@ -26,7 +26,8 @@ COMFY_DIR = Path(os.environ.get("OPEN_VIDEO_COMFYUI_DIR", LAB / "ComfyUI"))
 SERVER = os.environ.get("OPEN_VIDEO_COMFYUI", "http://127.0.0.1:8188")
 OUT = Path(os.environ.get("OPEN_VIDEO_OUTPUT", PRODUCT / "output"))
 REC = Path(os.environ.get("OPEN_VIDEO_RECEIPTS", PRODUCT / "artifacts" / "verify"))
-OUT.mkdir(parents=True, exist_ok=True); REC.mkdir(parents=True, exist_ok=True)
+# dirs are created lazily at write time — importing this module must not
+# touch the filesystem (it ships inside the wheel as open_video.scripts.*)
 sys.path.insert(0, str(PRODUCT / "scripts"))
 from h3_generate_benchmark import (VRAMSampler, ram_used_mb, http_json,
     queue_prompt, get_history, fetch_output, duration_to_length)
@@ -101,6 +102,7 @@ def run(a):
                "first_frame": a.first_frame, "last_frame": a.last_frame},
                "wall_s": round(t1-t0, 1), "peak_vram_mb": sampler.peak,
                "ram_used_mb": round(ram_used_mb()), "status": st, "outputs": out, "fetch_msg": msg}
+    REC.mkdir(parents=True, exist_ok=True)
     rp = REC/f"agent_{mode}_{int(t0)}.json"; rp.write_text(json.dumps(receipt, indent=2, default=str))
     return receipt
 

--- a/scripts/h3_generate_benchmark.py
+++ b/scripts/h3_generate_benchmark.py
@@ -22,8 +22,7 @@ SERVER = os.environ.get("OPEN_VIDEO_COMFYUI", "http://127.0.0.1:8188")
 WORKFLOWS = PRODUCT / "backends" / "h3" / "workflows"
 OUT_DIR = ROOT / "output"
 RECEIPT_DIR = ROOT / "artifacts/verify"
-OUT_DIR.mkdir(parents=True, exist_ok=True)
-RECEIPT_DIR.mkdir(parents=True, exist_ok=True)
+# created lazily at write time (no import-time filesystem side effects)
 
 # role -> (node_id, input_key) for workflows/h3_t2v_api.json
 NODE_ROLES = {
@@ -86,6 +85,7 @@ def fetch_output(pid, save_node):
     saved = []
     for fn, sub in files:
         url = f"{SERVER}/view?filename={fn}&subfolder={sub}&type=output"
+        OUT_DIR.mkdir(parents=True, exist_ok=True)
         p = OUT_DIR / f"{int(time.time())}_{fn}"
         urllib.request.urlretrieve(url, p); saved.append(str(p))
     return saved, "ok"
@@ -135,6 +135,7 @@ def run(args):
         "ram_start_mb": round(ram0, 0), "ram_end_mb": round(ram_used_mb(), 0),
         "outputs": out, "fetch_msg": msg,
     }
+    RECEIPT_DIR.mkdir(parents=True, exist_ok=True)
     rp = RECEIPT_DIR / f"bench_{int(t0)}_{args.width}x{args.height}_{args.duration}s.json"
     rp.write_text(json.dumps(receipt, indent=2))
     return receipt

--- a/tests/test_state_root.py
+++ b/tests/test_state_root.py
@@ -1,0 +1,49 @@
+"""State-root discipline: mutable state must never land inside an installed tree."""
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from open_video.core.config import is_installed_path  # noqa: E402
+from open_video.core.h3_weights import default_models_dir  # noqa: E402
+
+
+def test_is_installed_path():
+    assert is_installed_path(Path("/venv/lib/python3.12/site-packages/open_video"))
+    assert is_installed_path(Path("/usr/lib/python3/dist-packages/open_video"))
+    assert not is_installed_path(Path("/home/dev/open-video"))
+
+
+def test_models_dir_never_targets_site_packages(monkeypatch):
+    for var in ("OPEN_VIDEO_MODELS", "OPEN_VIDEO_LAB", "OPEN_VIDEO_HOME"):
+        monkeypatch.delenv(var, raising=False)
+    installed_root = Path("/venv/lib/python3.12/site-packages/open_video")
+    got = default_models_dir(installed_root)
+    assert "site-packages" not in got.parts
+    assert got == (Path.home() / ".open-video" / "models").resolve()
+
+
+def test_source_checkout_state_root_unchanged(monkeypatch):
+    monkeypatch.delenv("OPEN_VIDEO_HOME", raising=False)
+    import open_video.core.config as cfg
+    importlib.reload(cfg)
+    assert cfg.STATE_ROOT == cfg.ROOT  # source tree keeps historical behavior
+    assert cfg.OUTPUT == cfg.ROOT / "output"
+
+
+def test_scripts_import_has_no_filesystem_side_effects(tmp_path):
+    """Importing the shipped dev scripts must not create directories (Opus P2)."""
+    code = (
+        "import os, sys, pathlib\n"
+        f"os.chdir({str(tmp_path)!r})\n"
+        f"sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})\n"
+        "import open_video.scripts.h3_agent\n"
+        "import open_video.scripts.h3_generate_benchmark\n"
+        "print(sorted(p.name for p in pathlib.Path('.').iterdir()))\n"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True,
+                         timeout=60)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "[]", f"import created files: {out.stdout} {out.stderr}"


### PR DESCRIPTION
Improve-3: Opus review P2s + altitude-review data/state split. Installed wheels never write into site-packages (state defaults to ~/.open-video, models fallback included); shipped dev scripts no longer mkdir at import; CI wheel-smoke now enforces both. Source-checkout behavior unchanged (asserted by test). 49/49.