### PR TITLE
feat(harness): generate --json + skill accuracy pass

### DIFF
--- a/cli/open_video.py
+++ b/cli/open_video.py
@@ -320,6 +320,11 @@ def cmd_generate(args) -> int:
         print("[open-video] [4/5] --dry-run: prompt + plan validated. No generation performed.",
               flush=True)
         print("[open-video] [5/5] done (dry-run).", flush=True)
+        if getattr(args, "json", False):
+            print(json.dumps({"dry_run": True, "validated": True, "film": None,
+                              "shots": [{"scene_id": s_.scene_id, "mode": s_.mode,
+                                         "duration_s": s_.duration_s, "seed": s_.seed}
+                                        for s_ in shots]}))
         return 0
 
     # 12. engine + pipeline
@@ -343,6 +348,14 @@ def cmd_generate(args) -> int:
         print("[open-video] error: pipeline did not produce a film.", file=sys.stderr)
         return 4
     print(f"[open-video] [5/5] DONE -> {film}", flush=True)
+    if getattr(args, "json", False):
+        print(json.dumps({"dry_run": False, "film": film,
+                          "shots": [{"scene_id": s_.scene_id, "mode": s_.mode,
+                                     "seed": s_.seed, "video_path": s_.video_path,
+                                     "verdict": s_.verdict,
+                                     "judge_score": s_.receipt.get("judge_score"),
+                                     "judge_issues": s_.receipt.get("judge_issues", [])}
+                                    for s_ in shots]}))
     return 0
 
 
@@ -504,6 +517,10 @@ def build_generate_parser():
                         f"env OPEN_VIDEO_COMFYUI).")
     p.add_argument("--dry-run", action="store_true",
                    help="Validate prompt + show the plan, then exit without generating.")
+    p.add_argument("--json", action="store_true",
+                   help="Emit a machine-readable JSON result (film path + per-shot judge "
+                        "verdicts) as the final stdout line — the agent self-verification "
+                        "channel.")
     return p
 
 

--- a/library/plans/multishot_demo.json
+++ b/library/plans/multishot_demo.json
@@ -1,0 +1,7 @@
+{
+  "_doc": "Example plan for scripts/h3_multishot.py — run from the repo root: python scripts/h3_multishot.py --plan library/plans/multishot_demo.json --out output/long_demo.mp4. prompt_file paths are cwd-relative; duration is seconds per shot (<= 15).",
+  "shots": [
+    {"prompt_file": "library/prompts/official_t2va_starship.txt", "duration": 10, "first_frame": null},
+    {"prompt_file": "library/prompts/cinematic_cityspeed.txt", "duration": 8}
+  ]
+}

--- a/skill/h3-video/SKILL.md
+++ b/skill/h3-video/SKILL.md
@@ -101,7 +101,7 @@ python -m open_video recommend-quant
 ```bash
 cd "${H3_LAB:-$OPEN_VIDEO_ROOT/../lab}"
 curl -sf http://127.0.0.1:8188/system_stats || (
-  cd ComfyUI && nohup ../venv/bin/python main.py \
+  mkdir -p logs && cd ComfyUI && nohup ../venv/bin/python main.py \
     --listen 127.0.0.1 --port 8188 --lowvram --use-sage-attention \
     > ../logs/comfy_server.log 2>&1 &
 )
@@ -115,6 +115,8 @@ curl -sf http://127.0.0.1:8188/system_stats || (
 | + 1 image | **I2V** (+ instruction line) |
 | + first & last image | **FL2VA** (+ alignment line) |
 | Multi-ref identity/style | R2V (needs ref2va weights — not default) |
+
+CLI `--mode` tokens: `t2v` · `i2v` · `flf2v` (FL2VA ↔ `--mode flf2v`). R2V has no CLI token yet.
 
 ### C. Craft the 3-field prompt (quality lever #1)
 
@@ -144,8 +146,8 @@ non_diegetic_music: <1–3 sentences: instruments, tempo, rhythm — no vague mo
 ```bash
 cd "$OPEN_VIDEO_ROOT"
 python -m open_video run "$(cat prompts/my_shot.txt)" --duration 8 --dry-run
-# or lab harness:
-cd "$H3_LAB" && ./venv/bin/python scripts/h3_agent.py --prompt "$(cat …)" --dry-run
+# optional, only if a lab tree exists at $H3_LAB:
+#   cd "$H3_LAB" && ./venv/bin/python "$OPEN_VIDEO_ROOT/scripts/h3_agent.py" --prompt "$(cat …)" --dry-run
 ```
 
 Fix validator issues before GPU spend.
@@ -161,26 +163,25 @@ python -m open_video run "$(cat prompts/my_shot.txt)" \
 # aliases: open-video "…", open-video run "…"
 ```
 
-**Lab agent path (same quality stack, battle-tested on this machine):**
+I2V / FL2VA (product CLI — supply frames; FL2VA is `--mode flf2v`):
 
 ```bash
-cd "$H3_LAB"
-./venv/bin/python scripts/h3_agent.py \
-  --prompt "$(cat prompts/my_shot.txt)" \
-  --width 1344 --height 768 --duration 8 --seed 42
-# mp4 → output/   receipt → artifacts/verify/agent_*.json
+python -m open_video run "$(cat prompts/my_shot.txt)" \
+  --mode i2v --first-frame inputs/start.png --duration 8
+python -m open_video run "$(cat prompts/my_shot.txt)" \
+  --mode flf2v --first-frame inputs/start.png --last-frame inputs/end.png --duration 8
 ```
 
-I2V / FL2VA:
-
-```bash
-./venv/bin/python scripts/h3_agent.py --prompt "$(cat …)" \
-  --first-frame inputs/start.png [--last-frame inputs/end.png] \
-  --width 1344 --height 768 --duration 8
-```
+**Optional lab path** (only when a lab tree exists — `$H3_LAB` set, with its own venv):
+`cd "$H3_LAB" && ./venv/bin/python "$OPEN_VIDEO_ROOT/scripts/h3_agent.py" --prompt … --width 1344 --height 768 --duration 8 --seed 42` (mp4 → output/, receipt → artifacts/verify/agent_*.json).
 
 ### F. Review & iterate
 
+0. **Automatic VLM judge:** set `OPEN_VIDEO_VLM_URL` + `OPEN_VIDEO_VLM_MODEL`
+   (+ `OPEN_VIDEO_VLM_KEY`) to any OpenAI-compatible vision endpoint and the
+   pipeline judges every shot for real (score + issues in the `--json` output).
+   Without these env vars the judge auto-PASSes — then the manual review below
+   is mandatory, not optional.
 1. Play the mp4 (native audio matters).
 2. Extract a contact sheet:  
    `ffmpeg -y -i out.mp4 -vf "fps=1,scale=320:-1,tile=4x2" contact.png`
@@ -189,7 +190,15 @@ I2V / FL2VA:
 
 ### G. Deliver
 
-Tell the user: **path · duration · resolution · seed · mode · wall time** (from receipt).
+**Verify before claiming done:** exit code 0 AND `DONE -> <path>` printed, then
+
+```bash
+[ -f "$path" ] && ffprobe -v error -show_entries format=duration -of csv=p=0 "$path"
+```
+
+(or run with `--json` and read `film` + per-shot `verdict`/`judge_score` from the
+final stdout line). Only then tell the user: **path · duration · resolution ·
+seed · mode · wall time** (from receipt).
 
 ---
 
@@ -218,6 +227,9 @@ python -m open_video list-models
 | `OPEN_VIDEO_COMFYUI` | ComfyUI base URL |
 | `OPEN_VIDEO_MODEL` | Default backend (`h3`) |
 | `H3_LAB` | Optional lab tree with ComfyUI + h3_agent |
+| `OPEN_VIDEO_VLM_URL` | OpenAI-compatible vision endpoint → real judge |
+| `OPEN_VIDEO_VLM_MODEL` | Vision model id for the judge |
+| `OPEN_VIDEO_VLM_KEY` | Bearer token for the judge endpoint (optional) |
 
 ---
 

--- a/skill/open-video/SKILL.md
+++ b/skill/open-video/SKILL.md
@@ -28,8 +28,10 @@ the agent brain ComfyUI lacks: judge→refine + multi-shot stitch + coherence pl
 land**.
 
 **v0.0.1 honesty:** prefer [`skill/h3-video`](../h3-video/SKILL.md) for reliable high-quality
-single clips. Multi-minute film is the flagship *design*. `core/judge.py` is a **stub/scaffold** —
-without a wired `vision_fn` it may PASS by default; do not treat auto-PASS as a live vision loop.
+single clips. Multi-minute film is the flagship *design*. The judge is REAL when env-wired:
+set `OPEN_VIDEO_VLM_URL` + `OPEN_VIDEO_VLM_MODEL` (+ `OPEN_VIDEO_VLM_KEY`) to any
+OpenAI-compatible vision endpoint and every shot is scored + diagnosed automatically;
+with the env unset it is an honest PASS stub — then manual frame review is mandatory.
 Single open models still cap ~15s/shot; longer output needs multi-shot orchestration (partial).
 
 ## 2. Agentic procedure — run these steps in order
@@ -69,10 +71,12 @@ Confirm the server is up first (§3). H3 defaults: 1344×768, 20 steps, `res_mul
 scheduler, `shift_video=12.0` / `shift_audio=3.0`, INT8 ConvRot quants, engine flags
 `--lowvram --use-sage-attention`. `length` snaps to the 17k+5 grid.
 
-**Step 6 — Judge the output** (`core/judge.py` — design core; **stub without `vision_fn`**).
-Extract frames; if a real vision backend is wired, assess vs prompt intent + quality bar.
-Verdict: **PASS / REFINE / FAIL**. If no vision is wired, expect auto-PASS — you must
-**manually** review frames or call an external vision model. Record frames + verdict in the receipt.
+**Step 6 — Judge the output** (`core/judge.py`). Activate the real judge with env:
+`OPEN_VIDEO_VLM_URL` + `OPEN_VIDEO_VLM_MODEL` (+ `OPEN_VIDEO_VLM_KEY`) — the pipeline then
+extracts frames and assesses vs prompt intent + quality bar automatically
+(`QualityJudge.from_env()` is the entry point; explicit `QualityJudge(vision_fn=…)` also works).
+Verdict: **PASS / REFINE / FAIL**, with score + issues in the receipt (`run --json` exposes them).
+With the env unset the judge auto-PASSes — then you must manually review frames.
 
 **Step 7 — Refine if REFINE or FAIL.** Diagnose the *specific* issue, apply a *targeted* fix (prompt
 tweak / +steps / different mode / ref-pack for identity lock / different seed), regenerate. Strategy
@@ -100,9 +104,9 @@ Health check: `curl -s http://127.0.0.1:8188/system_stats` (returns JSON when up
 
 **Generate one shot — open-video Python API (the contract; lives in `backends/` + `engines/`):**
 ```python
-from backends.h3.backend import H3Backend
-from core.backend import ShotRequest
-from engines.comfyui.adapter import ComfyUIAdapter
+from open_video.backends.h3.backend import H3Backend
+from open_video.core.backend import ShotRequest
+from open_video.engines.comfyui.adapter import ComfyUIAdapter
 
 engine = ComfyUIAdapter(server="http://127.0.0.1:8188")
 backend = H3Backend()
@@ -110,7 +114,9 @@ req = ShotRequest(prompt=<3-field prompt string>, mode="t2v",
                   width=1344, height=768, duration_s=10.0, seed=0)
 result = backend.generate(req, engine=engine)   # → ShotResult(ok, video_path, receipt)
 ```
-- User-facing CLI (planned in `cli/`): `open-video "<concept>" --duration 300 --model h3`.
+- User-facing CLI (shipped): `open-video "<concept>" --duration 10 --model h3 --json`
+  (durations above ~15s trigger the multi-shot v0 template path — single-shot ≤15s uses your
+  prompt verbatim and is the reliable v0.0.1 route).
 - Proven baseline scripts (same workflows, ported from the early lab):
   - Single shot: `scripts/h3_agent.py --request "<simple NL>" --duration 5 --width 1344 --height 768`
     (use `--prompt "<full 3-field prompt>"` for best quality; `--first-frame`/`--last-frame` for I2V/FL2VA).
@@ -120,8 +126,9 @@ result = backend.generate(req, engine=engine)   # → ShotResult(ok, video_path,
 `plan` is a `list[Shot(scene_id, prompt, mode, duration_s, seed, …)]`. The pipeline generates each
 shot → judges → extracts last frame → chains (FL2VA handoff) → stitches → writes `output/film.mp4`
 and returns `(film_path, plan_with_receipts)`.
-- Proven baseline: `scripts/h3_multishot.py --plan plans/multishot_demo.json --out output/long_demo.mp4`
-  where plan JSON = `{"shots": [{"prompt_file": "...", "duration": 10, "first_frame": null}, …]}`.
+- Proven baseline: `scripts/h3_multishot.py --plan library/plans/multishot_demo.json --out output/long_demo.mp4`
+  (a ready example plan ships at `library/plans/multishot_demo.json`; plan JSON =
+  `{"shots": [{"prompt_file": "...", "duration": 10, "first_frame": null}, …]}`).
 
 ## 4. Constraints (H3 baseline — hard, evidence-based)
 

--- a/tests/test_cli_json.py
+++ b/tests/test_cli_json.py
@@ -1,0 +1,19 @@
+"""The generate --json self-verification channel (agent-facing contract)."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_dry_run_json_contract():
+    out = subprocess.run(
+        [sys.executable, str(REPO / "cli" / "open_video.py"),
+         "a blue test pattern", "--duration", "8", "--dry-run", "--json"],
+        capture_output=True, text=True, cwd=REPO, timeout=120)
+    assert out.returncode == 0, out.stderr
+    payload = json.loads(out.stdout.strip().splitlines()[-1])
+    assert payload["dry_run"] is True and payload["validated"] is True
+    assert payload["film"] is None
+    assert payload["shots"] and set(payload["shots"][0]) == {"scene_id", "mode", "duration_s", "seed"}


### PR DESCRIPTION
Improve-6: ccz (GLM) audited the agent skills against the shipped surface — 11 findings, all verified with line numbers. Load-bearing fixes: agents get a structured self-verification channel (generate --json), both skills now document the real judge env wiring, and four commands that would fail as written (fl2va token, lab paths, missing plan file, logs redirect) are runnable. Suite green on base; example plan validated.