### PR TITLE
feat(pipeline): judge-driven REFINE retries + single-pass extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ a hard validator, and curated presets (`open-video list-presets`).
 |---|---|---|
 | **Generate** | Local MiniMax H3 via ComfyUI — `pull` / `status` / `run` | Multi-model backends (Wan, LTX, …) |
 | **Agent path** | `skill/h3-video` crafts official prompts + drives the CLI | Full multi-shot director agent |
-| **Judge loop** | Real VLM judge via env `OPEN_VIDEO_VLM_URL/MODEL/KEY` (OpenAI-compatible); honest PASS stub when unset | Refine loop → best-of-N |
+| **Judge loop** | Real VLM judge via env `OPEN_VIDEO_VLM_URL/MODEL/KEY` + automatic REFINE retries (`OPEN_VIDEO_JUDGE_RETRIES`, best take kept); honest PASS stub when unset | Best-of-N tournament judging |
 | **Long film** | Single clips (H3 shot length) | Planner → stitch multi-minute film |
 | **Hosted try** | Site `/try` is a **browser mockup** | Real hosted generate |
 
-The full generate → judge → **refine** loop is the long-term design; today the judge scores and
-diagnoses (point `OPEN_VIDEO_VLM_URL` at any OpenAI-compatible vision model), and refine/regenerate
-is still manual.
+The generate → judge → **refine** loop runs today: point `OPEN_VIDEO_VLM_URL` at any
+OpenAI-compatible vision model and low-scoring shots regenerate automatically with a bumped
+seed (`OPEN_VIDEO_JUDGE_RETRIES` extra takes, best score kept — full take history in `--json`).
 
 ## Why local
 

--- a/core/judge.py
+++ b/core/judge.py
@@ -57,14 +57,20 @@ class QualityJudge:
                               "-show_entries", "stream=nb_read_frames", "-of", "csv=p=0", video_path],
                              capture_output=True, text=True, timeout=15)
         total = int(out.stdout.strip()) if out.stdout.strip().isdigit() else 120
-        idxs = [int(i * (total - 1) / max(self.n - 1, 1)) for i in range(self.n)]
+        idxs = sorted({int(i * (total - 1) / max(self.n - 1, 1)) for i in range(self.n)})
+        # one decode pass for all frames (was: one full ffmpeg run per frame)
+        select = "+".join(f"eq(n\\,{i})" for i in idxs)
+        pattern = frames_dir / f"shot{shot_id}_sel%d.png"
+        subprocess.run(["ffmpeg", "-y", "-v", "error", "-i", video_path,
+                        "-vf", f"select='{select}'", "-vsync", "passthrough",
+                        "-frames:v", str(len(idxs)), str(pattern)], check=False)
         paths = []
-        for idx in idxs:
-            p = frames_dir / f"shot{shot_id}_f{idx}.png"
-            subprocess.run(["ffmpeg", "-y", "-v", "error", "-i", video_path,
-                            "-vf", f"select=eq(n\\,{idx})", "-frames:v", "1", str(p)], check=False)
-            if p.exists():
-                paths.append(str(p))
+        for k, idx in enumerate(idxs, start=1):
+            src = frames_dir / f"shot{shot_id}_sel{k}.png"
+            dst = frames_dir / f"shot{shot_id}_f{idx}.png"
+            if src.exists():
+                src.replace(dst)
+                paths.append(str(dst))
         return paths
 
     def diagnose(self, vision_result: dict, prompt: str) -> list:

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -9,6 +9,7 @@ shot-by-shot loop and the FL2VA chain. Quality assessment goes through core.judg
 concat / last-frame extraction through core.stitcher.Stitcher, and the generation recipe is
 embedded in the output film via core.recipe.embed_recipe. No judge/stitch logic is duplicated here.
 """
+import os
 from datetime import datetime
 from pathlib import Path
 from dataclasses import dataclass, field
@@ -67,26 +68,48 @@ class LongFilmPipeline:
             ]
         return verdict.verdict != "FAIL"
 
-    # --- single-shot generation via backend ---
+    # --- single-shot generation via backend, with judge-driven retries ---
     def _run_shot(self, shot: Shot) -> bool:
-        # use backend's resolution_for if available, else default 1344x768
+        """Generate → judge; on REFINE regenerate with a bumped seed and keep the
+        best-scoring take. Retries only matter with a real judge (the stub
+        PASSes take 1). OPEN_VIDEO_JUDGE_RETRIES caps extra takes (default 1)."""
         try:
             w, h = self.backend.resolution_for("16:9") if self.backend else (1344, 768)
         except Exception:
             w, h = 1344, 768
-        req = ShotRequest(prompt=shot.prompt, mode=shot.mode, width=w, height=h,
-                          duration_s=shot.duration_s, seed=shot.seed,
-                          first_frame=shot.first_frame, last_frame=shot.last_frame,
-                          lora=shot.receipt.get("lora"), lora_weight=shot.receipt.get("lora_weight", 0.8),
-                          trigger_word=shot.receipt.get("trigger_word"))
-        result = self.backend.generate(req, engine=self.engine)  # FIX: pass engine through
-        if not result.ok:
-            shot.verdict = "FAIL"
-            shot.receipt["error"] = result.error
-            return False
-        shot.video_path = result.video_path
-        shot.receipt.update(result.receipt)
-        return self.judge(shot)
+        retries = max(0, int(os.environ.get("OPEN_VIDEO_JUDGE_RETRIES", "1") or 0))
+        takes = []
+        for attempt in range(retries + 1):
+            seed = shot.seed + attempt * 100
+            req = ShotRequest(prompt=shot.prompt, mode=shot.mode, width=w, height=h,
+                              duration_s=shot.duration_s, seed=seed,
+                              first_frame=shot.first_frame, last_frame=shot.last_frame,
+                              lora=shot.receipt.get("lora"),
+                              lora_weight=shot.receipt.get("lora_weight", 0.8),
+                              trigger_word=shot.receipt.get("trigger_word"))
+            result = self.backend.generate(req, engine=self.engine)
+            if not result.ok:
+                shot.verdict = "FAIL"
+                shot.receipt["error"] = result.error
+                shot.receipt["takes"] = takes
+                return False
+            shot.video_path = result.video_path
+            shot.receipt.update(result.receipt)
+            ok = self.judge(shot)
+            takes.append({"attempt": attempt + 1, "seed": seed,
+                          "video_path": shot.video_path, "verdict": shot.verdict,
+                          "judge_score": shot.receipt.get("judge_score"),
+                          "judge_issues": shot.receipt.get("judge_issues", [])})
+            if not ok or shot.verdict != "REFINE":
+                break
+        # keep the best take by judge score (None sorts lowest)
+        best = max(takes, key=lambda t: (t["judge_score"] is not None, t["judge_score"]))
+        shot.video_path = best["video_path"]
+        shot.verdict = best["verdict"]
+        shot.receipt["judge_score"] = best["judge_score"]
+        shot.receipt["judge_issues"] = best["judge_issues"]
+        shot.receipt["takes"] = takes
+        return shot.verdict != "FAIL"
 
     # --- recipe assembly for embed_recipe (self-documenting + remixable output) ---
     def _build_recipe(self, plan: list, film_path: str) -> dict:

--- a/skill/h3-video/SKILL.md
+++ b/skill/h3-video/SKILL.md
@@ -230,6 +230,7 @@ python -m open_video list-models
 | `OPEN_VIDEO_VLM_URL` | OpenAI-compatible vision endpoint → real judge |
 | `OPEN_VIDEO_VLM_MODEL` | Vision model id for the judge |
 | `OPEN_VIDEO_VLM_KEY` | Bearer token for the judge endpoint (optional) |
+| `OPEN_VIDEO_JUDGE_RETRIES` | Extra takes on REFINE verdicts (default 1; best score kept) |
 
 ---
 

--- a/tests/test_e2e_fake_comfyui.py
+++ b/tests/test_e2e_fake_comfyui.py
@@ -130,3 +130,37 @@ def test_stitcher_concat_real_ffmpeg(tmp_path):
     out = Stitcher(output_dir=str(tmp_path)).concat([str(a), str(b)], str(tmp_path / "film.mp4"))
     assert out and Path(out).exists()
     assert 0.8 <= _duration(out) <= 1.3  # two 0.5s clips stitched
+
+
+def test_refine_retry_keeps_best_take(tmp_path, monkeypatch):
+    """REFINE on take 1 → retry with bumped seed; best-scoring take wins."""
+    from open_video.core.pipeline import LongFilmPipeline, Shot
+
+    monkeypatch.setenv("OPEN_VIDEO_JUDGE_RETRIES", "1")
+    clip = _tiny_mp4(tmp_path / "src.mp4")
+    fake = FakeComfy(clip, pending_polls=0)
+    scores = iter([0.3, 0.9])
+
+    def vision_fn(frames, prompt):
+        return {"score": next(scores), "missing_elements": [], "artifacts": "",
+                "motion_quality": "good", "incoherence": False}
+
+    try:
+        engine = ComfyUIAdapter(server=fake.url, output_dir=str(tmp_path / "out"))
+        orig_wait = engine.wait
+        engine.wait = lambda pid, timeout=1800, poll=3.0: orig_wait(pid, timeout=30, poll=0.05)
+        pipe = LongFilmPipeline(backend=H3Backend(), engine=engine,
+                                output_dir=str(tmp_path / "out"), vision_fn=vision_fn)
+        shot = Shot(scene_id=1, prompt="a blue test pattern, static camera",
+                    mode="t2v", duration_s=2.0, seed=7)
+        ok = pipe._run_shot(shot)
+    finally:
+        fake.close()
+
+    assert ok
+    assert len(fake.submitted) == 2, "REFINE must trigger exactly one retry"
+    seeds = [wf["prompt"]["noise"]["inputs"]["noise_seed"] for wf in fake.submitted]
+    assert seeds == [7, 107]
+    takes = shot.receipt["takes"]
+    assert [t["judge_score"] for t in takes] == [0.3, 0.9]
+    assert shot.receipt["judge_score"] == 0.9 and shot.verdict == "PASS"


### PR DESCRIPTION
Improve-7: the judge's verdicts now drive regeneration — REFINE retries with a bumped seed, best take kept, history in receipts/--json. Frame extraction collapsed to one decode pass (efficiency-review follow-up). Stub-judge behavior unchanged. 52/52 incl. a new e2e retry test.