### PR TITLE
fix(judge): normalize stringly-typed VLM booleans

### DIFF
--- a/core/judge.py
+++ b/core/judge.py
@@ -73,6 +73,13 @@ class QualityJudge:
                 paths.append(str(dst))
         return paths
 
+    @staticmethod
+    def _flag(value) -> bool:
+        """VLMs return booleans as strings — treat 'false'/'none'/'no'/'' as False."""
+        if isinstance(value, str):
+            return value.strip().lower() not in ("", "false", "none", "no", "0")
+        return bool(value)
+
     def diagnose(self, vision_result: dict, prompt: str) -> list:
         """Parse vision-model output into structured issues + fixes."""
         issues = []
@@ -80,13 +87,13 @@ class QualityJudge:
         for elem in vision_result.get("missing_elements", []):
             issues.append(Issue(type="dropped_element", detail=f"'{elem}' from prompt not visible",
                                 fix=f"emphasize '{elem}' earlier + more explicitly in the prompt"))
-        if vision_result.get("artifacts"):
-            issues.append(Issue(type="artifact", detail=vision_result["artifacts"],
+        if self._flag(vision_result.get("artifacts")):
+            issues.append(Issue(type="artifact", detail=str(vision_result["artifacts"]),
                                 fix="try different seed or add resolution/stability constraint"))
         if vision_result.get("motion_quality") == "poor":
             issues.append(Issue(type="bad_motion", detail="motion is choppy/unnatural",
                                 fix="increase steps to 25 or adjust camera amplitude/speed"))
-        if vision_result.get("incoherence"):
+        if self._flag(vision_result.get("incoherence")):
             issues.append(Issue(type="incoherence", detail="frames don't flow coherently",
                                 fix="simplify the shot to single-action; reduce cut count"))
         return issues

--- a/tests/test_judge_vlm.py
+++ b/tests/test_judge_vlm.py
@@ -102,3 +102,14 @@ def test_env_activation(monkeypatch):
     monkeypatch.setenv("OPEN_VIDEO_VLM_MODEL", "test-vlm")
     assert vision_fn_from_env() is not None
     assert QualityJudge.from_env().vision_fn is not None
+
+
+def test_diagnose_ignores_stringly_false_flags():
+    """VLMs emit 'false' as a string; it must not create spurious issues (film60 field bug)."""
+    judge = QualityJudge()
+    raw = {"score": 0.8, "missing_elements": [], "artifacts": "none",
+           "motion_quality": "good", "incoherence": "false"}
+    assert judge.diagnose(raw, "prompt") == []
+    raw_bad = {"score": 0.4, "missing_elements": [], "artifacts": "heavy banding",
+               "motion_quality": "good", "incoherence": "frames jump around"}
+    assert {i.type for i in judge.diagnose(raw_bad, "p")} == {"artifact", "incoherence"}


### PR DESCRIPTION
Found in the field by the Phase-0 film run (film-director lane): llama-3.2-90b-vision returns `incoherence: "false"` as a string; diagnose() treated it truthy → spurious issue + REFINE on every shot. One normalizer + regression test from the real payload. 53/53.